### PR TITLE
Padding for higher octree levels and minor patches

### DIFF
--- a/inc/Forge.h
+++ b/inc/Forge.h
@@ -18,6 +18,8 @@
 #include <vector>
 #include <list>
 
+#include <glm/glm.hpp>
+
 namespace osp {
   
 class BricksHeader;
@@ -80,7 +82,7 @@ private:
   // Read metadata from VDF file and calculate additional metadata
   bool ReadMetadata();
   // Create an octree for every timestep, save in one common file
-  bool CreateOctree();
+  bool CreateOctrees();
   // Delete the created temp files
   bool DeleteTempFiles();
   // Use temp octrees to create TSP tree 
@@ -89,12 +91,23 @@ private:
   // Points to first data entry after header
   off headerOffset_;
 
+  bool buildDataLevels(std::FILE* file, unsigned int timestep, std::vector< std::vector<float> >& levelData);
+  bool createPadding(std::vector< std::vector<float> >& levelData, std::vector< std::vector<float> >& paddedLevelData);
+  bool buildOctree(std::vector< std::vector<float> >& paddedLevelData, std::vector< Brick<float>* >& octreeBricks);
+
   // Calculate Z-order index from x, y, z coordinates
   uint32_t ZOrder(uint16_t x, uint16_t y, uint16_t z);
 
+  glm::ivec3 linearToCartesian(unsigned int linearCoords, int dim);
+  glm::ivec3 linearToCartesian(unsigned int linearCoords, int xDim, int yDim, int zDim);
+  glm::ivec3 linearToCartesian(unsigned int linearCoords, glm::ivec3 dim);
+  unsigned int cartesianToLinear(glm::ivec3 cartesianCoords, int dim);
+  unsigned int cartesianToLinear(glm::ivec3 cartesianCoords, int xDim, int yDim, int zDim);
+  unsigned int cartesianToLinear(glm::ivec3 cartesianCoords, glm::ivec3 dim);
+
 };
 
-}
+} // namespace osp
 
 #endif
 

--- a/src/Forge.cpp
+++ b/src/Forge.cpp
@@ -646,7 +646,6 @@ bool Forge::ConstructTSPTree() {
 
     fclose(in);
     fclose(out);
-
     BSTLevel--;
     numTimestepsInLevel /= 2;
                 
@@ -691,16 +690,18 @@ bool Forge::ConstructTSPTree() {
     off inFileSize = ftello(in);
     fseeko(in, 0, SEEK_SET);
     
-    std::vector<float> buffer((size_t)inFileSize/sizeof(float));
-    // Read whole file, write to out file
-    //in.read(reinterpret_cast<char*>(&buffer[0]), floatSize);
-    fread(reinterpret_cast<void*>(&buffer[0]), 
-                                  static_cast<size_t>(inFileSize), 1, in);
+    off chunkSize = 1024 * 1024 * 512; // Write a maximum of 512 MB at a time
+    std::vector<float> buffer((size_t)chunkSize/sizeof(float));
 
-    //out.write(reinterpret_cast<char*>(&buffer[0]), floatSize); 
-    fwrite(reinterpret_cast<void*>(&buffer[0]), 
-                                  static_cast<size_t>(inFileSize), 1, out);
-    //std::cout << "Pos after writing: " << ftello(out) << std::endl;
+    for (off offset = 0; offset < inFileSize; offset += chunkSize) {
+      off thisSize = std::min(chunkSize, inFileSize - offset);
+
+      fread(reinterpret_cast<void*>(&buffer[0]),
+              static_cast<size_t>(thisSize), 1, in);
+
+      fwrite(reinterpret_cast<void*>(&buffer[0]),
+              static_cast<size_t>(thisSize), 1, out);
+    }
 
     fclose(in);
   }

--- a/src/Forge.cpp
+++ b/src/Forge.cpp
@@ -646,7 +646,9 @@ bool Forge::ConstructTSPTree() {
 
     fclose(in);
     fclose(out);
-    BSTLevel--;
+    if (BSTLevel > 0) {
+      BSTLevel--;
+    }
     numTimestepsInLevel /= 2;
                 
   } while (BSTLevel != 0);


### PR DESCRIPTION
The physical size of padding increases with the level in the octree. Therefore, a brick of higher level cannot simply be a combination of its children. The third commit is a fix for that and the prior two are smaller fixes for certain volume edge cases.
